### PR TITLE
Fix case where git returns a dash instead of a number

### DIFF
--- a/lua/CommitReminder/init.lua
+++ b/lua/CommitReminder/init.lua
@@ -27,8 +27,10 @@ local function count_diff()
 	local added = 0
 	local removed = 0
 	for i=1,table.getn(changed_lines),3 do
-		added = added + tonumber(changed_lines[i])
-		removed = removed + tonumber(changed_lines[i + 1])
+		if changed_lines[i] ~= "-" then
+			added = added + tonumber(changed_lines[i])
+			removed = removed + tonumber(changed_lines[i + 1])
+		end
 	end
 	return {added=added, removed=removed}
 end


### PR DESCRIPTION
Example `git diff --numstat` output with dashes:
```
...
16      20     file.md
-       -       Attachments/Pasted image 20210730223708.png
9       2       file.md
...
```

Fixes:
```
Error detected while processing BufWritePost Autocommands for "*":
E5108: Error executing lua ...cker/opt/neovim-git-reminder/lua/CommitReminder/init.lua:33: attempt to perform arithmetic on a nil value
stack traceback:
        ...cker/opt/neovim-git-reminder/lua/CommitReminder/init.lua:33: in function 'count_diff'
        ...cker/opt/neovim-git-reminder/lua/CommitReminder/init.lua:63: in function 'cycle'
        [string ":lua"]:1: in main chunk
```